### PR TITLE
fix: pass table with "TextChanged" to autocomplete field for cmp setup

### DIFF
--- a/lua/kanban.lua
+++ b/lua/kanban.lua
@@ -53,7 +53,7 @@ function M.setup(options)
 	M.theme.init(M)
 	require("cmp").setup.filetype({ "kanban" }, {
 		completion = {
-			autocomplete = true,
+			autocomplete = { "TextChanged" },
 		},
 	})
 end


### PR DESCRIPTION
As defined in nvim-cmp/lua/cmp/types/cmp.lua:115 and :23, the autocomplete field
expects either `false` or a table of "InsertEnter" or "TextChanged" strings. So
far in this project, `true` literal was passed to the autocomplete field when
setting up cmp for the "kanban" filetype. This caused throwing "expected table,
got boolean" error during text insertion into kanban tasks.