### PR TITLE
add expand for create new description file

### DIFF
--- a/lua/kanban/fn/description/add.lua
+++ b/lua/kanban/fn/description/add.lua
@@ -26,8 +26,8 @@ function M.add(kanban)
 	local win = vim.api.nvim_open_win(kanban.items.description.buf_nr, true, kanban.items.description.buf_conf)
 	vim.api.nvim_win_set_option(win, "winhighlight", "NormalFloat:KanbanFloat")
 	local current_md_dir = string.gsub(kanban.kanban_md_path, "/[^/]+$", "")
-	if vim.fn.isdirectory(current_md_dir .. "/" .. kanban.ops.markdown.description_folder) == 0 then
-		vim.fn.mkdir(current_md_dir .. "/" .. kanban.ops.markdown.description_folder)
+	if vim.fn.isdirectory(vim.fn.expand(current_md_dir .. "/" .. kanban.ops.markdown.description_folder)) == 0 then
+		vim.fn.mkdir(vim.fn.expand(current_md_dir .. "/" .. kanban.ops.markdown.description_folder))
 	end
 	local file_path = current_md_dir .. "/" .. kanban.ops.markdown.description_folder .. task.title .. ".md"
 	vim.cmd(":e " .. file_path)


### PR DESCRIPTION
Hello,

I have been using your plugin and find it extremely useful. 
I made a few improvements locally and would like to propose these changes through this pull request.
In my environment, since the target file is often located under the home directory, I thought it would be more convenient if '~' could be expanded. I believe this change will not interfere with other use cases. 
Thank you for your time and consideration.

Best regards,
yugapanda