### PR TITLE
Generalize cmp completion match helpers

### DIFF
--- a/lua/kanban/fn/cmp/blink/cmp.lua
+++ b/lua/kanban/fn/cmp/blink/cmp.lua
@@ -9,169 +9,43 @@ local M = {}
 
 -- ===== 内部ユーティリティ =====
 
-local function uniq(list)
-  local seen, out = {}, {}
-  for _, v in ipairs(list) do
-    if v and v ~= '' and not seen[v] then
-      seen[v] = true
-      table.insert(out, v)
-    end
+local cmp_common = require('kanban.fn.cmp.common')
+
+local cmp_types = (function()
+  local ok, types = pcall(require, 'blink.cmp.types')
+  if ok and types and types.CompletionItemKind then
+    return types.CompletionItemKind
   end
-  return out
-end
-
-local function format_date(t)
-  return os.date('@%Y/%m/%d', t)
-end
-
--- `@today`, `@2d`, `@1w`, `@2m`, `@1y`, `@mo`..`@su`, `@/MM/DD`, `@//DD`
-local function expand_due_token(tok)
-  if not tok or tok:sub(1, 1) ~= '@' then return nil end
-
-  if tok == '@today' or tok == '@tod' or tok == '@to' then
-    return format_date(os.time())
-  end
-
-  local d = tok:match('^@(%d+)d$')
-  if d then return format_date(os.time() + (tonumber(d) * 24 * 60 * 60)) end
-
-  local w = tok:match('^@(%d+)w$')
-  if w then return format_date(os.time() + (tonumber(w) * 7 * 24 * 60 * 60)) end
-
-  local m = tok:match('^@(%d+)m$')
-  if m then
-    local t = os.date('*t')
-    for _ = 1, tonumber(m) do
-      if t.month == 12 then
-        t.year = t.year + 1
-        t.month = 1
-      else
-        t.month = t.month + 1
-      end
-    end
-    return string.format('@%04d/%02d/%02d', t.year, t.month, t.day)
-  end
-
-  local y = tok:match('^@(%d+)y$')
-  if y then
-    local t = os.date('*t')
-    t.year = t.year + tonumber(y)
-    return string.format('@%04d/%02d/%02d', t.year, t.month, t.day)
-  end
-
-  do
-    local mm, dd = tok:match('^@/(%d%d)/(%d%d)$')
-    if mm and dd then
-      local t = os.date('*t')
-      return string.format('@%04d/%s/%s', t.year, mm, dd)
-    end
-  end
-  do
-    local dd = tok:match('^@//(%d%d)$')
-    if dd then
-      local t = os.date('*t')
-      return string.format('@%04d/%02d/%s', t.year, t.month, dd)
-    end
-  end
-
-  do
-    local n_part, wd = tok:match('^@(n*)([a-z][a-z])$')
-    if wd then
-      local step_week_num = #n_part
-      local base = os.time()
-      local today = os.date('*t')
-      local sunday = base - ((today.wday - 1) * 24 * 60 * 60)
-      local target = sunday + (step_week_num * 7 * 24 * 60 * 60)
-      local map = { su = 0, mo = 1, tu = 2, we = 3, th = 4, fr = 5, sa = 6 }
-      local offset = map[wd]
-      if offset ~= nil then
-        target = target + (offset * 24 * 60 * 60)
-        return format_date(target)
-      end
-    end
-  end
-
-  return nil
-end
+  return { Text = 1 }
+end)()
 
 local function due_candidates(prefix)
-  local tokens = {
-    '@today', '@1d', '@2d', '@3d', '@5d', '@7d',
-    '@1w', '@2w', '@3w',
-    '@1m', '@2m', '@3m',
-    '@1y', '@2y',
-    '@su', '@mo', '@tu', '@we', '@th', '@fr', '@sa',
-    '@nmo', '@ntu', '@nwe', '@nth', '@nfr', '@nsa', '@nsu',
+  local docs = {
+    direct = { kind = 'plaintext', value = '入力済みトークンを日付へ展開' },
+    preset = { kind = 'plaintext', value = '期日トークンを日付へ展開' },
   }
-  local items = {}
-  for _, tok in ipairs(tokens) do
-    if tok:sub(1, #prefix) == prefix then
-      local expanded = expand_due_token(tok)
-      if expanded then
-        table.insert(items, {
-          label = tok .. ' → ' .. expanded,
-          insertText = expanded,
-          filterText = tok,
-          kind = require('blink.cmp.types').CompletionItemKind.Text,
-          documentation = { kind = 'plaintext', value = '期日トークンを日付へ展開' },
-        })
-      end
-    end
-  end
-  local direct = expand_due_token(prefix)
-  if direct then
-    table.insert(items, 1, {
-      label = prefix .. ' → ' .. direct,
-      insertText = direct,
-      filterText = prefix,
-      kind = require('blink.cmp.types').CompletionItemKind.Text,
-      documentation = { kind = 'plaintext', value = '入力済みトークンを日付へ展開' },
-    })
-  end
-  local seen, out = {}, {}
-  for _, it in ipairs(items) do
-    local key = it.insertText or it.label
-    if not seen[key] then
-      seen[key] = true
-      table.insert(out, it)
-    end
-  end
-  return out
-end
 
-local function collect_tags(kanban)
-  local tags = {}
-  if not kanban or not kanban.items or not kanban.items.lists then return tags end
-  for _, list in ipairs(kanban.items.lists) do
-    if list and list.tasks then
-      for _, task in ipairs(list.tasks) do
-        if task and type(task.tag) == 'table' then
-          for _, t in ipairs(task.tag) do
-            if type(t) == 'string' and t ~= '' then table.insert(tags, t) end
-          end
-        end
-      end
-    end
-  end
-  return uniq(tags)
+  return cmp_common.map_due_matches(prefix, function(match)
+    return {
+      label = match.token .. ' → ' .. match.expanded,
+      insertText = match.expanded,
+      filterText = match.token,
+      kind = cmp_types.Text,
+      documentation = match.is_direct and docs.direct or docs.preset,
+    }
+  end)
 end
 
 local function tag_candidates(kanban, prefix)
-  local p = prefix:sub(2):lower()
-  local items = {}
-  for _, tag in ipairs(collect_tags(kanban)) do
-    local tl = string.lower(tag)
-    if tl:sub(1, #p) == p then
-      table.insert(items, {
-        label = '#' .. tag,
-        insertText = '#' .. tag,
-        filterText = '#' .. tag,
-        kind = require('blink.cmp.types').CompletionItemKind.Text,
-        documentation = { kind = 'plaintext', value = '既存タグから補完' },
-      })
-    end
-  end
-  return items
+  return cmp_common.map_tag_matches(kanban, prefix, function(tag)
+    return {
+      label = '#' .. tag,
+      insertText = '#' .. tag,
+      filterText = '#' .. tag,
+      kind = cmp_types.Text,
+      documentation = { kind = 'plaintext', value = '既存タグから補完' },
+    }
+  end)
 end
 
 -- 検索対象トークンと置換範囲を取得

--- a/lua/kanban/fn/cmp/common.lua
+++ b/lua/kanban/fn/cmp/common.lua
@@ -1,0 +1,242 @@
+local M = {}
+
+local DUE_TOKENS = {
+  '@today', '@1d', '@2d', '@3d', '@5d', '@7d',
+  '@1w', '@2w', '@3w',
+  '@1m', '@2m', '@3m',
+  '@1y', '@2y',
+  '@su', '@mo', '@tu', '@we', '@th', '@fr', '@sa',
+  '@nmo', '@ntu', '@nwe', '@nth', '@nfr', '@nsa', '@nsu',
+}
+
+local WEEKDAY_OFFSET = { su = 0, mo = 1, tu = 2, we = 3, th = 4, fr = 5, sa = 6 }
+
+local SECONDS_IN_DAY = 24 * 60 * 60
+local SECONDS_IN_WEEK = 7 * SECONDS_IN_DAY
+
+---Create a shallow unique copy of the given list while preserving order.
+---@generic T
+---@param list T[]
+---@param key_fn fun(item: T): any
+---@return T[]
+function M.unique(list, key_fn)
+  local seen, result = {}, {}
+  local selector = key_fn or function(value)
+    return value
+  end
+  for _, value in ipairs(list) do
+    local key = selector(value)
+    if key ~= nil and key ~= '' and not seen[key] then
+      seen[key] = true
+      table.insert(result, value)
+    end
+  end
+  return result
+end
+
+local function format_date(time_value)
+  return os.date('@%Y/%m/%d', time_value)
+end
+
+---Expand known due tokens (e.g. "@today", "@2d") into concrete dates.
+---@param token string
+---@return string|nil
+function M.expand_due_token(token)
+  if not token or token:sub(1, 1) ~= '@' then
+    return nil
+  end
+
+  if token == '@today' or token == '@tod' or token == '@to' then
+    return format_date(os.time())
+  end
+
+  local days = token:match('^@(%d+)d$')
+  if days then
+    return format_date(os.time() + (tonumber(days) * SECONDS_IN_DAY))
+  end
+
+  local weeks = token:match('^@(%d+)w$')
+  if weeks then
+    return format_date(os.time() + (tonumber(weeks) * SECONDS_IN_WEEK))
+  end
+
+  local months = token:match('^@(%d+)m$')
+  if months then
+    local calendar = os.date('*t')
+    for _ = 1, tonumber(months) do
+      if calendar.month == 12 then
+        calendar.year = calendar.year + 1
+        calendar.month = 1
+      else
+        calendar.month = calendar.month + 1
+      end
+    end
+    return string.format('@%04d/%02d/%02d', calendar.year, calendar.month, calendar.day)
+  end
+
+  local years = token:match('^@(%d+)y$')
+  if years then
+    local calendar = os.date('*t')
+    calendar.year = calendar.year + tonumber(years)
+    return string.format('@%04d/%02d/%02d', calendar.year, calendar.month, calendar.day)
+  end
+
+  do
+    local month, day = token:match('^@/(%d%d)/(%d%d)$')
+    if month and day then
+      local calendar = os.date('*t')
+      return string.format('@%04d/%s/%s', calendar.year, month, day)
+    end
+  end
+
+  do
+    local day = token:match('^@//(%d%d)$')
+    if day then
+      local calendar = os.date('*t')
+      return string.format('@%04d/%02d/%s', calendar.year, calendar.month, day)
+    end
+  end
+
+  do
+    local week_prefix, weekday = token:match('^@(n*)([a-z][a-z])$')
+    if weekday then
+      local step_weeks = #week_prefix
+      local base = os.time()
+      local today = os.date('*t')
+      local sunday = base - ((today.wday - 1) * SECONDS_IN_DAY)
+      local target = sunday + (step_weeks * SECONDS_IN_WEEK)
+      local offset = WEEKDAY_OFFSET[weekday]
+      if offset ~= nil then
+        target = target + (offset * SECONDS_IN_DAY)
+        return format_date(target)
+      end
+    end
+  end
+
+  return nil
+end
+
+---Return due token matches for the given prefix.
+---@param prefix string
+---@return table[]
+function M.due_token_matches(prefix)
+  if not prefix or prefix == '' then
+    return {}
+  end
+
+  local matches = {}
+  local direct = M.expand_due_token(prefix)
+  if direct then
+    table.insert(matches, { token = prefix, expanded = direct, is_direct = true })
+  end
+
+  for _, token in ipairs(DUE_TOKENS) do
+    if token:sub(1, #prefix) == prefix then
+      local expanded = M.expand_due_token(token)
+      if expanded then
+        table.insert(matches, { token = token, expanded = expanded, is_direct = token == prefix })
+      end
+    end
+  end
+
+  return M.unique(matches, function(item)
+    return item.expanded
+  end)
+end
+
+---@class KanbanCmpDueMatch
+---@field token string
+---@field expanded string
+---@field is_direct boolean
+
+---Map due token matches with a builder function.
+---@generic T
+---@param prefix string
+---@param build fun(match: KanbanCmpDueMatch): T|nil
+---@return T[]
+function M.map_due_matches(prefix, build)
+  if type(build) ~= 'function' then
+    return {}
+  end
+
+  local items = {}
+  for _, match in ipairs(M.due_token_matches(prefix)) do
+    local item = build(match)
+    if item ~= nil then
+      table.insert(items, item)
+    end
+  end
+
+  return items
+end
+
+---Collect unique tags from the current kanban state.
+---@param kanban table|nil
+---@return string[]
+function M.collect_tags(kanban)
+  local tags = {}
+  if not kanban or not kanban.items or not kanban.items.lists then
+    return tags
+  end
+
+  for _, list in ipairs(kanban.items.lists) do
+    if list and list.tasks then
+      for _, task in ipairs(list.tasks) do
+        if task and type(task.tag) == 'table' then
+          for _, tag in ipairs(task.tag) do
+            if type(tag) == 'string' and tag ~= '' then
+              table.insert(tags, tag)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  return M.unique(tags)
+end
+
+---Return existing tags that match the given completion prefix.
+---@param kanban table|nil
+---@param prefix string
+---@return string[]
+function M.tag_prefix_matches(kanban, prefix)
+  if not prefix or prefix == '' then
+    return {}
+  end
+
+  local tags = {}
+  local normalized = prefix:sub(2):lower()
+  for _, tag in ipairs(M.collect_tags(kanban)) do
+    local lower_tag = string.lower(tag)
+    if lower_tag:sub(1, #normalized) == normalized then
+      table.insert(tags, tag)
+    end
+  end
+
+  return tags
+end
+
+---Map tag matches with a builder function.
+---@generic T
+---@param kanban table|nil
+---@param prefix string
+---@param build fun(tag: string): T|nil
+---@return T[]
+function M.map_tag_matches(kanban, prefix, build)
+  if type(build) ~= 'function' then
+    return {}
+  end
+
+  local items = {}
+  for _, tag in ipairs(M.tag_prefix_matches(kanban, prefix)) do
+    local item = build(tag)
+    if item ~= nil then
+      table.insert(items, item)
+    end
+  end
+
+  return items
+end
+
+return M

--- a/lua/kanban/fn/cmp/nvim-cmp.lua
+++ b/lua/kanban/fn/cmp/nvim-cmp.lua
@@ -29,191 +29,36 @@ local function p_require(name)
   return nil
 end
 
-local function uniq(list)
-  local seen, out = {}, {}
-  for _, v in ipairs(list) do
-    if v ~= nil and v ~= '' and not seen[v] then
-      seen[v] = true
-      table.insert(out, v)
-    end
-  end
-  return out
-end
-
--- YYYY/MM/DD へ展開
-local function format_date(t)
-  return os.date("@%Y/%m/%d", t)
-end
-
--- `@today`, `@2d`, `@1w`, `@2m`, `@1y`, `@mo`..`@su` を実日付に展開
-local function expand_due_token(tok)
-  if not tok or tok:sub(1,1) ~= '@' then return nil end
-
-  -- today
-  if tok == '@today' or tok == '@tod' or tok == '@to' then
-    return format_date(os.time())
-  end
-
-  -- Nx: days/weeks/months/years
-  do
-    local d = tok:match('^@(%d+)d$')
-    if d then
-      local sec = os.time() + (tonumber(d) * 24 * 60 * 60)
-      return format_date(sec)
-    end
-  end
-  do
-    local w = tok:match('^@(%d+)w$')
-    if w then
-      local sec = os.time() + (tonumber(w) * 7 * 24 * 60 * 60)
-      return format_date(sec)
-    end
-  end
-  do
-    local m = tok:match('^@(%d+)m$')
-    if m then
-      local t = os.date('*t')
-      for _ = 1, tonumber(m) do
-        if t.month == 12 then
-          t.year = t.year + 1
-          t.month = 1
-        else
-          t.month = t.month + 1
-        end
-      end
-      return string.format('@%04d/%02d/%02d', t.year, t.month, t.day)
-    end
-  end
-  do
-    local y = tok:match('^@(%d+)y$')
-    if y then
-      local t = os.date('*t')
-      t.year = t.year + tonumber(y)
-      return string.format('@%04d/%02d/%02d', t.year, t.month, t.day)
-    end
-  end
-
-  -- @/MM/DD or //@DD
-  do
-    local mm, dd = tok:match('^@/(%d%d)/(%d%d)$')
-    if mm and dd then
-      local t = os.date('*t')
-      return string.format('@%04d/%s/%s', t.year, mm, dd)
-    end
-  end
-  do
-    local dd = tok:match('^@//(%d%d)$')
-    if dd then
-      local t = os.date('*t')
-      return string.format('@%04d/%02d/%s', t.year, t.month, dd)
-    end
-  end
-
-  -- week day: @su..@sa または n を重ねて翌週以降
-  do
-    local n_part, wd = tok:match('^@(n*)([a-z][a-z])$')
-    if wd then
-      local step_week_num = #n_part
-      local base = os.time()
-      local today = os.date('*t')
-      -- Lua: Sunday=1 ... Saturday=7
-      local sunday = base - ((today.wday - 1) * 24 * 60 * 60)
-      local target = sunday + (step_week_num * 7 * 24 * 60 * 60)
-      local map = { su=0, mo=1, tu=2, we=3, th=4, fr=5, sa=6 }
-      local offset = map[wd]
-      if offset ~= nil then
-        target = target + (offset * 24 * 60 * 60)
-        return format_date(target)
-      end
-    end
-  end
-
-  return nil
-end
+local cmp_common = require('kanban.fn.cmp.common')
 
 local function due_candidates(prefix)
-  -- 代表的トークン候補。前方一致で提示し、`insertText` は展開後の日付にする
-  local tokens = {
-    '@today', '@1d', '@2d', '@3d', '@5d', '@7d',
-    '@1w', '@2w', '@3w',
-    '@1m', '@2m', '@3m',
-    '@1y', '@2y',
-    '@su', '@mo', '@tu', '@we', '@th', '@fr', '@sa',
-    '@nmo', '@ntu', '@nwe', '@nth', '@nfr', '@nsa', '@nsu',
-  }
-  local items = {}
-  for _, tok in ipairs(tokens) do
-    if tok:sub(1, #prefix) == prefix then
-      local expanded = expand_due_token(tok)
-      if expanded then
-        table.insert(items, {
-          label = tok .. ' → ' .. expanded,
-          insertText = expanded,
-          filterText = tok,
-          kind = 21, -- Text
-          documentation = '期日トークンを日付へ展開して挿入します',
-        })
-      end
+  return cmp_common.map_due_matches(prefix, function(match)
+    local documentation
+    if match.is_direct then
+      documentation = '入力済みトークンを日付へ展開'
+    else
+      documentation = '期日トークンを日付へ展開して挿入します'
     end
-  end
-  -- プレフィクス自体が完全トークンなら、直接展開候補も追加
-  local direct = expand_due_token(prefix)
-  if direct then
-    table.insert(items, 1, {
-      label = prefix .. ' → ' .. direct,
-      insertText = direct,
-      filterText = prefix,
-      kind = 21,
-      documentation = '入力済みトークンを日付へ展開',
-    })
-  end
-  -- 重複排除（同じ展開候補が複数回並ばないように）
-  local seen, out = {}, {}
-  for _, it in ipairs(items) do
-    local key = (it.insertText or it.label)
-    if not seen[key] then
-      seen[key] = true
-      table.insert(out, it)
-    end
-  end
-  return out
-end
-
-local function collect_tags(kanban)
-  local tags = {}
-  if not kanban or not kanban.items or not kanban.items.lists then return tags end
-  for _, list in ipairs(kanban.items.lists) do
-    if list and list.tasks then
-      for _, task in ipairs(list.tasks) do
-        if task and type(task.tag) == 'table' then
-          for _, t in ipairs(task.tag) do
-            if type(t) == 'string' and t ~= '' then
-              table.insert(tags, t)
-            end
-          end
-        end
-      end
-    end
-  end
-  return uniq(tags)
+    return {
+      label = match.token .. ' → ' .. match.expanded,
+      insertText = match.expanded,
+      filterText = match.token,
+      kind = 21, -- Text
+      documentation = documentation,
+    }
+  end)
 end
 
 local function tag_candidates(kanban, prefix)
-  local p = prefix:sub(2):lower() -- remove '#'
-  local items = {}
-  for _, tag in ipairs(collect_tags(kanban)) do
-    local tl = string.lower(tag)
-    if tl:sub(1, #p) == p then
-      table.insert(items, {
-        label = '#' .. tag,
-        insertText = '#' .. tag,
-        filterText = '#' .. tag,
-        kind = 1, -- Text
-        documentation = '既存タグから補完',
-      })
-    end
-  end
-  return items
+  return cmp_common.map_tag_matches(kanban, prefix, function(tag)
+    return {
+      label = '#' .. tag,
+      insertText = '#' .. tag,
+      filterText = '#' .. tag,
+      kind = 1, -- Text
+      documentation = '既存タグから補完',
+    }
+  end)
 end
 
 -- ===== cmp ソース =====


### PR DESCRIPTION
## Summary
- add mapping helpers in `kanban.fn.cmp.common` to centralize due and tag match building
- update the blink.cmp and nvim-cmp integrations to use the shared builders
- guard the blink completion kind require so the source loads even when blink.cmp types are missing

## Testing
- not run (luacheck unavailable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690de1e438a88333983881dc2aca3b52)