### PR TITLE
Added config option to change the default lists

### DIFF
--- a/lua/kanban.lua
+++ b/lua/kanban.lua
@@ -79,12 +79,16 @@ function M.kanban_create(path)
 		return
 	end
 	M.items = {}
-	M.items.lists = {
-		{ title = "TODO", tasks = {} },
-		{ title = "Work in progress", tasks = {} },
-		{ title = "Done", tasks = {} },
-		{ title = "Archive", tasks = {} },
-	}
+	if M.ops.markdown.default_lists then
+		M.items.lists = M.ops.markdown.default_lists
+	else
+		M.items.lists = {
+			{ title = "TODO", tasks = {} },
+			{ title = "Work in progress", tasks = {} },
+			{ title = "Done", tasks = {} },
+			{ title = "Archive", tasks = {} },
+		}
+	end
 	markdown.writer.write(M, path)
 end
 

--- a/lua/kanban.lua
+++ b/lua/kanban.lua
@@ -79,15 +79,46 @@ function M.kanban_create(path)
 		return
 	end
 	M.items = {}
+	local preset_list = {
+		{ title = "TODO", tasks = {} },
+		{ title = "Work in progress", tasks = {} },
+		{ title = "Done", tasks = {} },
+		{ title = "Archive", tasks = {} },
+	}
 	if M.ops.markdown.default_lists then
-		M.items.lists = M.ops.markdown.default_lists
+		local err = nil
+		local formatted_list = nil
+		-- Check the format of the lists
+		-- Returns all valid entries in the proper format in the first return variable
+		-- Returns any errors as an array and ignores them, or if the input is completely
+		-- wrong it will return as a string and error out
+		formatted_list, err = require("kanban.utils").check_lists(M.ops.markdown.default_lists)
+		if type(err) == "string" then
+			-- The error is a string if the default_lists parameter is not a table
+			-- Raise an error, do not create a file
+			vim.notify(err, vim.log.levels.ERROR)
+			return
+		else
+			-- If some of the inputs are incorrect, raise a warning for each incorrect entry with the index
+			-- Create the file, excluding the bad values
+			for i, _ in pairs(err) do
+				local msg = ("Improper input for default_lists at index " .. tostring(i))
+				vim.notify(msg, vim.log.levels.WARN)
+			end
+		end
+		-- Count number of valid entries
+		local count = 0
+		for _ in pairs(formatted_list) do count = count + 1 end
+		if count < 1 then
+			-- If no valid entries for default_list, count will be zero
+			-- Raise an error, do not create a file
+			vim.notify("No valid entries in default_lists", vim.log.levels.ERROR)
+			return
+		end
+		M.items.lists = formatted_list
 	else
-		M.items.lists = {
-			{ title = "TODO", tasks = {} },
-			{ title = "Work in progress", tasks = {} },
-			{ title = "Done", tasks = {} },
-			{ title = "Archive", tasks = {} },
-		}
+		-- If default_list is not specified by the user, use the preset one
+		M.items.lists = preset_list
 	end
 	markdown.writer.write(M, path)
 end

--- a/lua/kanban/ops.lua
+++ b/lua/kanban/ops.lua
@@ -35,6 +35,7 @@ function M.get_ops(options)
 				"```",
 				"%%",
 			},
+			default_lists = nil
 		},
 		hl = {
 			{

--- a/lua/kanban/utils.lua
+++ b/lua/kanban/utils.lua
@@ -77,4 +77,46 @@ function Utils.file_exists(path)
 	end
 	return fh ~= nil
 end
+
+---Check the user provided default_lists for any errors. 
+---Return both a properly formatted list of valid entries and, separately, any invalid entries.
+---
+---@param default_lists string[] | {title: string, tasks: table?}[] 
+---@return {title: string, tasks: table?}[]
+---@return table | string
+function Utils.check_lists(default_lists)
+	if type(default_lists) ~= "table" then
+		-- If default_lists is not a table, 
+		return {}, string.format(
+			"default_lists is type %s not table",
+			tostring(type(default_lists))
+		)
+	end
+	local formatted_entries = {}
+	local bad_entries = {}
+	for i, v in ipairs(default_lists) do
+		if type(v) == "string" then
+			formatted_entries[i] = {title = v, tasks={}}
+		elseif type(v) == "table" then
+			if not v["title"] then
+				-- Invalid entry as no title present
+				bad_entries[i] = v
+			else
+				if not v["tasks"] then
+					-- Title present but no tasks
+					local entry = v
+					entry["tasks"] = {}
+					formatted_entries[i] = entry
+				else
+					-- Tasks are present
+					-- Don't currently check for validity of tasks (TODO?)
+					formatted_entries[i] = v
+				end
+			end
+		else
+			bad_entries[i] = v
+		end
+	end
+	return formatted_entries, bad_entries
+end
 return Utils


### PR DESCRIPTION
When creating a new board, the lists were hard-coded and could not be configured by the user. This PR adds a `default_lists` config option in the `markdown` table which allows the user to specify the initial lists that will be used when creating a new board. The prior defaults are used if the config option is not set.

This is useful when working on multiple projects that require a different board structure.

This functionality could probably use documenting, I'm happy to add a section to the README prior to merge if needed.

Example config for alternative board layout:
```lua
config = function()
			require("kanban").setup({
				markdown= {
					description_foler = "./tasks/",
					due_format = "YYYY/MM/DD",
					list_head = "## ",
					default_lists = {
						{
							title = "Backlog", tasks={}
						},
						{
							title = "In Progress", tasks={}
						},
						{
							title = "Review", tasks={}
						},
						{
							title = "Complete",
							tasks = {
								{
									check = false,
									lines = {
										"This Pull Request",
										"@2026/02/19"
									}
								},
							}
						},
						{
							title = "Blocked", tasks={}
						}
					}
				},
			})
		end,
```

- I could not get the tests in the tests folder to run due to missing dependencies, despite running `make prepare`. I have tested this myself manually.
- I initially wanted to add the hardcoded lists to the ops module but this caused some weird issues with the tableMerge function. 